### PR TITLE
fix: avoid audio context leak when trimming silence

### DIFF
--- a/mp3gon/services/audioProcessor.ts
+++ b/mp3gon/services/audioProcessor.ts
@@ -768,12 +768,17 @@ function trimSilence(buffer: AudioBuffer, threshold = 0.005): AudioBuffer {
     if (firstSample === 0) return buffer;
 
     const newLength = buffer.length - firstSample;
-    const newBuffer = new AudioContext().createBuffer(buffer.numberOfChannels, newLength, buffer.sampleRate);
+    const newBuffer = new AudioBuffer({
+        length: newLength,
+        numberOfChannels: buffer.numberOfChannels,
+        sampleRate: buffer.sampleRate,
+    });
 
-    for(let i = 0; i < buffer.numberOfChannels; i++) {
-        newBuffer.copyToChannel(buffer.getChannelData(i).slice(firstSample), i);
+    for (let i = 0; i < buffer.numberOfChannels; i++) {
+        const channelData = buffer.getChannelData(i).subarray(firstSample);
+        newBuffer.copyToChannel(channelData, i, 0);
     }
-    
+
     return newBuffer;
 }
 


### PR DESCRIPTION
## Summary
- avoid creating an AudioContext just to build buffers, preventing leaks during silence trimming

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68956321de7c83258ad1ad0ad063ea22