### PR TITLE
feat: add error boundary component

### DIFF
--- a/mp3gon/components/ErrorBoundary.tsx
+++ b/mp3gon/components/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error?: Error;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 text-center">
+          <h2 className="text-xl font-bold text-red-500 mb-2">Something went wrong.</h2>
+          {this.state.error && (
+            <pre className="text-sm text-red-400 whitespace-pre-wrap">
+              {this.state.error.message}
+            </pre>
+          )}
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/mp3gon/index.tsx
+++ b/mp3gon/index.tsx
@@ -1,7 +1,7 @@
-
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,6 +11,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` component for handling runtime errors
- wrap the root `App` component with `ErrorBoundary`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6896c13e1c1c832584d3b04fa51a91ba