### PR TITLE
feat: add retrieval and codec LM skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build-index:
+	audioindex-build --in_glob 'data/wavs/*.wav' --seg beats --out_idx artifacts/idx.faiss --out_meta artifacts/meta.json --cache .cache/clap
+
+query:
+	audioindex-query --idx artifacts/idx.faiss --meta artifacts/meta.json --text "funk guitar mutes" --topk 10
+
+train-codec:
+	codeclm-train

--- a/audioindex/__init__.py
+++ b/audioindex/__init__.py
@@ -1,0 +1,1 @@
+"""Audio segment retrieval utilities."""

--- a/audioindex/cli/build.py
+++ b/audioindex/cli/build.py
@@ -1,0 +1,49 @@
+import argparse
+import glob
+import json
+import os
+
+import faiss
+import soundfile as sf
+import numpy as np
+import torch
+
+from ..segmentation import segments_on_onsets, segments_on_beats
+from ..embeddings import embed_audio_segment
+from ..index import SegmentIndex, SegMeta
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in_glob", required=True)
+    ap.add_argument("--seg", choices=["onsets", "beats"], default="beats")
+    ap.add_argument("--out_idx", required=True)
+    ap.add_argument("--out_meta", required=True)
+    ap.add_argument("--cache", default=None)
+    args = ap.parse_args()
+
+    idx = SegmentIndex(dim=512)
+    seg_fn = segments_on_beats if args.seg == "beats" else segments_on_onsets
+    metas, feats = [], []
+
+    for path in glob.glob(args.in_glob):
+        y, sr = sf.read(path, dtype="float32")
+        if y.ndim == 2:
+            y = y.mean(axis=1)
+        segs = seg_fn(y, sr)
+        for j, (s, e) in enumerate(segs):
+            s_i, e_i = int(s * sr), int(e * sr)
+            z = embed_audio_segment(torch.from_numpy(y[s_i:e_i]), sr, cache_dir=args.cache)
+            feats.append(z.squeeze(0))
+            metas.append(SegMeta(track_id=os.path.basename(path), seg_id=j,
+                                 start=float(s), end=float(e), sr=sr, path=path))
+
+    X = np.stack(feats, axis=0)
+    idx.add(X, metas)
+    faiss.write_index(idx.index, args.out_idx)
+    with open(args.out_meta, "w") as f:
+        json.dump([m.__dict__ for m in metas], f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/audioindex/cli/query.py
+++ b/audioindex/cli/query.py
@@ -1,0 +1,43 @@
+import argparse
+import json
+
+import faiss
+import numpy as np
+import soundfile as sf
+import torch
+
+from ..embeddings import embed_text_queries, embed_audio_segment
+from ..index import SegmentIndex, SegMeta
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--idx")
+    ap.add_argument("--meta")
+    ap.add_argument("--text")
+    ap.add_argument("--wav")
+    ap.add_argument("--topk", type=int, default=10)
+    args = ap.parse_args()
+
+    base = SegmentIndex(dim=512)
+    base.index = faiss.read_index(args.idx)
+    metas = [SegMeta(**m) for m in json.load(open(args.meta))]
+    base.metas = metas
+
+    if args.text:
+        Q = embed_text_queries([args.text])
+    else:
+        y, sr = sf.read(args.wav, dtype="float32")
+        if y.ndim == 2:
+            y = y.mean(axis=1)
+        Q = embed_audio_segment(torch.from_numpy(y), sr)
+
+    results = base.search(Q, topk=args.topk)[0]
+    print(json.dumps([
+        {"track": m.track_id, "seg": m.seg_id, "start": m.start, "end": m.end, "score": score}
+        for m, score in results
+    ], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/audioindex/embeddings.py
+++ b/audioindex/embeddings.py
@@ -1,0 +1,44 @@
+import hashlib
+import os
+from typing import Optional, List
+
+import numpy as np
+import torch
+import torchaudio
+from laion_clap import CLAP_Module
+
+SR_CLAP = 48_000
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+_clap_model = None
+
+def _clap():
+    global _clap_model
+    if _clap_model is None:
+        m = CLAP_Module(enable_fusion=False).to(DEVICE).eval()
+        m.load_ckpt("clap_htsat_fused")
+        _clap_model = m
+    return _clap_model
+
+
+def _hash_arr(arr: np.ndarray) -> str:
+    return hashlib.sha1(arr.tobytes()).hexdigest()[:16]
+
+
+def embed_audio_segment(wav: torch.Tensor, sr: int, cache_dir: Optional[str] = None) -> np.ndarray:
+    if wav.dim() == 1:
+        wav = wav.unsqueeze(0)
+    wav = torchaudio.functional.resample(wav, sr, SR_CLAP)
+    key = _hash_arr(wav.cpu().numpy()) if cache_dir else None
+    path = os.path.join(cache_dir, f"{key}.npy") if cache_dir else None
+    if path and os.path.exists(path):
+        return np.load(path)
+    z = _clap().get_audio_embedding_from_data(x=wav.to(DEVICE)).cpu().numpy()
+    if path:
+        os.makedirs(cache_dir, exist_ok=True)
+        np.save(path, z)
+    return z
+
+
+def embed_text_queries(texts: List[str]) -> np.ndarray:
+    return _clap().get_text_embedding(texts).cpu().numpy()

--- a/audioindex/index.py
+++ b/audioindex/index.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import faiss
+import numpy as np
+
+
+@dataclass
+class SegMeta:
+    track_id: str
+    seg_id: int
+    start: float
+    end: float
+    sr: int
+    path: str
+
+
+class SegmentIndex:
+    def __init__(self, dim: int = 512):
+        self.index = faiss.IndexFlatIP(dim)
+        self.metas: List[SegMeta] = []
+
+    @staticmethod
+    def _l2n(x: np.ndarray) -> np.ndarray:
+        return x / (np.linalg.norm(x, axis=1, keepdims=True) + 1e-9)
+
+    def add(self, X: np.ndarray, metas: List[SegMeta]) -> None:
+        Xn = self._l2n(X.astype(np.float32))
+        self.index.add(Xn)
+        self.metas.extend(metas)
+
+    def search(self, Q: np.ndarray, topk: int = 10) -> List[List[Tuple[SegMeta, float]]]:
+        Qn = self._l2n(Q.astype(np.float32))
+        D, I = self.index.search(Qn, topk)
+        out: List[List[Tuple[SegMeta, float]]] = []
+        for b in range(Q.shape[0]):
+            out.append([(self.metas[i], float(D[b, j])) for j, i in enumerate(I[b]) if i != -1])
+        return out

--- a/audioindex/io.py
+++ b/audioindex/io.py
@@ -1,0 +1,11 @@
+import soundfile as sf
+import numpy as np
+
+
+def slice_wav(path: str, sr: int, start: float, end: float) -> np.ndarray:
+    y, srx = sf.read(path, dtype="float32")
+    if y.ndim == 2:
+        y = y.mean(axis=1)
+    assert srx == sr, f"SR mismatch: {srx} vs {sr}"
+    s_i, e_i = int(start * sr), int(end * sr)
+    return y[s_i:e_i]

--- a/audioindex/retrieve.py
+++ b/audioindex/retrieve.py
@@ -1,0 +1,15 @@
+from typing import List
+import torch
+
+from .embeddings import embed_text_queries, embed_audio_segment
+from .index import SegmentIndex
+
+
+def text_to_segments(text: str, idx: SegmentIndex, topk: int = 10):
+    q = embed_text_queries([text])
+    return idx.search(q, topk=topk)[0]
+
+
+def audio_to_segments(wav: torch.Tensor, sr: int, idx: SegmentIndex, topk: int = 10):
+    q = embed_audio_segment(wav, sr)
+    return idx.search(q, topk=topk)[0]

--- a/audioindex/segmentation.py
+++ b/audioindex/segmentation.py
@@ -1,0 +1,20 @@
+import numpy as np
+import librosa
+
+HOP = 512
+
+def _bounds_from_frames(frames: np.ndarray, n_samples: int) -> np.ndarray:
+    last_f = int(np.ceil(n_samples / HOP))
+    return np.r_[0, frames, last_f]
+
+def segments_on_onsets(y, sr):
+    onset_frames = librosa.onset.onset_detect(y=y, sr=sr, hop_length=HOP, backtrack=True)
+    bounds = _bounds_from_frames(onset_frames, len(y))
+    times = librosa.frames_to_time(bounds, sr=sr, hop_length=HOP)
+    return list(zip(times[:-1], times[1:]))
+
+def segments_on_beats(y, sr):
+    _, beats = librosa.beat.beat_track(y=y, sr=sr, hop_length=HOP, units="frames")
+    bounds = _bounds_from_frames(beats, len(y))
+    times = librosa.frames_to_time(bounds, sr=sr, hop_length=HOP)
+    return list(zip(times[:-1], times[1:]))

--- a/audioindex/tests/audio_synth_utils.py
+++ b/audioindex/tests/audio_synth_utils.py
@@ -1,0 +1,7 @@
+
+def click_track(sr: int, T: float, freq: int = 2):
+    import numpy as np
+    y = np.zeros(int(sr * T), dtype="float32")
+    step = sr // freq
+    y[::step] = 1.0
+    return y

--- a/audioindex/tests/test_index.py
+++ b/audioindex/tests/test_index.py
@@ -1,0 +1,17 @@
+import pytest
+np = pytest.importorskip("numpy")
+faiss = pytest.importorskip("faiss")
+
+
+from audioindex.index import SegmentIndex, SegMeta
+
+
+def test_search_shapes():
+    idx = SegmentIndex(dim=2)
+    X = np.array([[1, 0], [0, 1]], dtype=np.float32)
+    metas = [SegMeta("a", 0, 0.0, 1.0, 1, "a.wav"), SegMeta("b", 0, 0.0, 1.0, 1, "b.wav")]
+    idx.add(X, metas)
+    Q = np.array([[1, 0]], dtype=np.float32)
+    out = idx.search(Q, topk=1)
+    assert len(out[0]) == 1
+    assert out[0][0][0].track_id == "a"

--- a/audioindex/tests/test_segmentation.py
+++ b/audioindex/tests/test_segmentation.py
@@ -1,0 +1,16 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+librosa = pytest.importorskip("librosa")
+
+from audioindex.segmentation import segments_on_beats
+from audioindex.tests.audio_synth_utils import click_track
+
+
+def test_bounds_monotonic():
+    sr = 24000
+    T = 2.0
+    y = click_track(sr, T, freq=2)  # beats every 0.5s
+    segs = segments_on_beats(y, sr)
+    assert all(b > a for a, b in segs)

--- a/codeclm/__init__.py
+++ b/codeclm/__init__.py
@@ -1,0 +1,1 @@
+"""Codec language model utilities."""

--- a/codeclm/dataset.py
+++ b/codeclm/dataset.py
@@ -1,0 +1,24 @@
+import glob
+import soundfile as sf
+import torch
+from torch.utils.data import Dataset
+
+from .tokenize import to_24k_mono, encode_encodec
+from .packing import pack_codes
+
+
+class TokenDataset(Dataset):
+    def __init__(self, glob_wav: str, codec, max_len: int = 8192):
+        self._paths = glob.glob(glob_wav)
+        self.codec = codec
+        self.max_len = max_len
+
+    def __len__(self) -> int:
+        return len(self._paths)
+
+    def __getitem__(self, i: int):
+        y, sr = sf.read(self._paths[i], dtype="float32")
+        t = to_24k_mono(y, sr)
+        codes = encode_encodec(t, self.codec)
+        seq = pack_codes(codes)[: self.max_len]
+        return {"tokens": seq}

--- a/codeclm/infer.py
+++ b/codeclm/infer.py
@@ -1,0 +1,18 @@
+import torch
+
+from .model import CodecGPT
+from .packing import unpack_codes
+
+
+def generate(model: CodecGPT, prompt: torch.LongTensor, max_len: int = 100) -> torch.LongTensor:
+    model.eval()
+    with torch.no_grad():
+        out = [prompt]
+        for _ in range(max_len):
+            x = torch.cat(out, dim=1)
+            logits = model(x)
+            next_tok = torch.argmax(logits[:, -1], dim=-1, keepdim=True)
+            out.append(next_tok)
+            if int(next_tok.item()) == 2:  # EOS
+                break
+        return torch.cat(out, dim=1)

--- a/codeclm/model.py
+++ b/codeclm/model.py
@@ -1,0 +1,26 @@
+import torch
+import torch.nn as nn
+
+
+class CodecGPT(nn.Module):
+    def __init__(self, vocab_size, d: int = 768, n_layer: int = 12, n_head: int = 12,
+                 max_len: int = 8192, pdrop: float = 0.1):
+        super().__init__()
+        self.tok = nn.Embedding(vocab_size, d)
+        self.pos = nn.Embedding(max_len, d)
+        self.blocks = nn.ModuleList(
+            [nn.TransformerEncoderLayer(d, n_head, 4 * d, batch_first=True,
+                                        activation="gelu", dropout=pdrop)
+             for _ in range(n_layer)]
+        )
+        self.norm = nn.LayerNorm(d)
+        self.head = nn.Linear(d, vocab_size)
+
+    def forward(self, x, cond=None):
+        B, T = x.shape
+        h = self.tok(x) + self.pos(torch.arange(T, device=x.device))[None]
+        if cond is not None:
+            h = torch.cat([cond, h], 1)
+        for blk in self.blocks:
+            h = blk(h)
+        return self.head(self.norm(h))[:, -T:]

--- a/codeclm/packing.py
+++ b/codeclm/packing.py
@@ -1,0 +1,27 @@
+import torch
+
+SEP, EOS = 1, 2
+
+def pack_codes(codebooks: list[torch.LongTensor]) -> torch.LongTensor:
+    T = codebooks[0].numel()
+    seq = []
+    for t in range(T):
+        for cb in codebooks:
+            seq.append(int(cb[t]))
+        seq.append(SEP)
+    seq.append(EOS)
+    return torch.tensor(seq, dtype=torch.long)
+
+
+def unpack_codes(seq: torch.LongTensor, n_codebooks: int) -> list[torch.LongTensor]:
+    buckets = [[] for _ in range(n_codebooks)]
+    k = 0
+    for tok in seq.tolist():
+        if tok == EOS:
+            break
+        if tok == SEP:
+            k = 0
+            continue
+        buckets[k].append(tok)
+        k += 1
+    return [torch.tensor(b, dtype=torch.long) for b in buckets]

--- a/codeclm/tests/test_packing.py
+++ b/codeclm/tests/test_packing.py
@@ -1,0 +1,14 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from codeclm.packing import pack_codes, unpack_codes
+
+
+def test_round_trip():
+    c1 = torch.tensor([1, 2, 3])
+    c2 = torch.tensor([4, 5, 6])
+    seq = pack_codes([c1, c2])
+    out1, out2 = unpack_codes(seq, 2)
+    assert torch.equal(c1, out1)
+    assert torch.equal(c2, out2)

--- a/codeclm/tests/test_tiny_train.py
+++ b/codeclm/tests/test_tiny_train.py
@@ -1,0 +1,12 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from codeclm.model import CodecGPT
+
+
+def test_forward_shapes():
+    model = CodecGPT(vocab_size=10, d=16, n_layer=1, n_head=2, max_len=16)
+    x = torch.randint(0, 10, (2, 5))
+    y = model(x)
+    assert y.shape == (2, 5, 10)

--- a/codeclm/tokenize.py
+++ b/codeclm/tokenize.py
@@ -1,0 +1,19 @@
+import torch
+import torchaudio
+import numpy as np
+
+TARGET_SR = 24_000
+
+def to_24k_mono(y: np.ndarray, sr: int) -> torch.Tensor:
+    t = torch.from_numpy(y.astype("float32"))
+    if t.ndim == 2:
+        t = t.mean(1)
+    t = t.unsqueeze(0)
+    if sr != TARGET_SR:
+        t = torchaudio.functional.resample(t, sr, TARGET_SR)
+    return t
+
+
+def encode_encodec(t_24k: torch.Tensor, codec) -> list[torch.LongTensor]:
+    codes = codec.encode(t_24k)
+    return [c.squeeze(0).cpu().long() for c in codes]

--- a/codeclm/train.py
+++ b/codeclm/train.py
@@ -1,0 +1,42 @@
+import torch
+import torch.nn as nn
+import yaml
+from torch.utils.data import DataLoader
+
+from .dataset import TokenDataset
+from .model import CodecGPT
+
+
+def train(cfg_path: str = "configs/codec24k.yaml"):
+    cfg = yaml.safe_load(open(cfg_path))
+    ds = TokenDataset(cfg["data"]["glob"], codec=None, max_len=cfg["train"]["ctx"])
+    dl = DataLoader(
+        ds,
+        batch_size=cfg["train"]["batch"],
+        shuffle=True,
+        collate_fn=lambda b: {"tokens": nn.utils.rnn.pad_sequence([x["tokens"] for x in b], batch_first=True, padding_value=0)},
+    )
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = CodecGPT(
+        vocab_size=cfg["model"]["vocab"],
+        d=cfg["model"]["d"],
+        n_layer=cfg["model"]["L"],
+        n_head=cfg["model"]["H"],
+        max_len=cfg["train"]["ctx"],
+    ).to(device)
+    opt = torch.optim.AdamW(model.parameters(), lr=cfg["train"]["lr"])
+    for step, batch in enumerate(dl):
+        x = batch["tokens"][:, :-1].to(device)
+        y = batch["tokens"][:, 1:].to(device)
+        logits = model(x)
+        loss = nn.functional.cross_entropy(logits.reshape(-1, logits.size(-1)), y.reshape(-1), label_smoothing=0.1)
+        loss.backward()
+        nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        opt.step()
+        opt.zero_grad()
+        if step % 50 == 0:
+            print(f"step {step} loss {loss.item():.3f}")
+
+
+if __name__ == "__main__":
+    train()

--- a/configs/codec24k.yaml
+++ b/configs/codec24k.yaml
@@ -1,0 +1,3 @@
+model: { vocab: 3072, d: 768, L: 12, H: 12 }
+data:  { glob: "data/wavs/*.wav" }
+train: { lr: 3.0e-4, batch: 8, ctx: 8192 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "sonichrome"
+version = "0.1.0"
+dependencies = [
+  "numpy",
+  "soundfile",
+  "librosa>=0.10",
+  "faiss-cpu",
+  "torch",
+  "torchaudio",
+  "laion-clap",
+  "PyYAML",
+  "pytest"
+]
+
+[project.scripts]
+audioindex-build = "audioindex.cli.build:main"
+audioindex-query = "audioindex.cli.query:main"
+codeclm-train   = "codeclm.train:train"

--- a/scripts/build_segments_json.py
+++ b/scripts/build_segments_json.py
@@ -1,0 +1,11 @@
+"""Utility to build segments.json for MP3gon overlay."""
+
+import json
+from pathlib import Path
+
+from audioindex.index import SegMeta
+
+
+def build_segments(metas: list[SegMeta], out_path: str) -> None:
+    data = [m.__dict__ for m in metas]
+    Path(out_path).write_text(json.dumps(data, indent=2))

--- a/scripts/mp3gon_demo_export.py
+++ b/scripts/mp3gon_demo_export.py
@@ -1,0 +1,1 @@
+"""Demo script placeholder for MP3gon integration."""


### PR DESCRIPTION
## Summary
- add CLAP-based audio segment retrieval utilities and CLI
- scaffold codec language model components (tokenization, model, training)
- include configuration, Makefile targets, and basic tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a712ccdf7483258a19221cba7a921e